### PR TITLE
Change useragent to something that doesn't get blocked

### DIFF
--- a/PixivConfig.py
+++ b/PixivConfig.py
@@ -57,8 +57,7 @@ class PixivConfig():
     __items = [
         ConfigItem("Network", "useProxy", False),
         ConfigItem("Network", "proxyAddress", ""),
-        ConfigItem("Network", "useragent",
-                   "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/115.0"),
+        ConfigItem("Network", "useragent", "Mozilla/5.0"),
         ConfigItem("Network", "useRobots", True),
         ConfigItem("Network", "timeout", 60),
         ConfigItem("Network", "retry", 3),


### PR DESCRIPTION
Looks like https://github.com/Nandaka/PixivUtil2/issues/1239 is still the case, with pixiv now blocking the current user agent, too. Switching it to the recommended value from 1239, however, works.